### PR TITLE
Add Shaman Chain Heal min/max rank controls and fix bugs

### DIFF
--- a/QuickHeal.lua
+++ b/QuickHeal.lua
@@ -63,8 +63,12 @@ local DQHV = { -- Default values
     OverhealCancelThreshold = 50,
     MTList = {},
     SkipList = {},
-    MinrankValueNH = 1,                            -- Minimum rank for Normal Heal (HT/FH/etc)
-    MinrankValueFH = 1,                            -- Minimum rank for Fast Heal (RG/HL/etc)
+    MinrankValueNH = 1,                            -- Minimum rank for Normal Heal (HW/HT/etc)
+    MinrankValueFH = 1,                            -- Minimum rank for Fast Heal (LHW/RG/etc)
+    MinrankValueCH = 1,                            -- Minimum rank for Chain Heal (Shaman only)
+    DownrankValueNH = 12,                          -- Maximum rank for Normal Heal (default: 12 for max class ranks)
+    DownrankValueFH = 7,                           -- Maximum rank for Fast Heal (default: 7 for max class ranks)
+    DownrankValueCH = 3,                           -- Maximum rank for Chain Heal (Shaman only)
     PrecastAggro = false,                          -- Precast spells on aggro targets even when not meeting general healing threshold
     PrecastAggroPreference = "HIGHEST_MAX_HEALTH", -- Preference for aggro target selection: HIGHEST_MAX_HEALTH or LOWEST_MAX_HEALTH
     PreHOTAggro = false,                           -- Pre-HOT aggro targets even when not meeting general healing threshold
@@ -1121,14 +1125,16 @@ local function Initialise()
         FindHealSpellToUse = QuickHeal_Shaman_FindHealSpellToUse;
         FindHealSpellToUseNoTarget = QuickHeal_Shaman_FindHealSpellToUseNoTarget;
         GetRatioHealthyExplanation = QuickHeal_Shaman_GetRatioHealthyExplanation;
+
+        -- Note: Chain Heal sliders are in QuickHealConfig_RanksFrame (430px), not QuickHeal_DownrankSlider
+
+        -- Healing Wave / Lesser Healing Wave sliders
         QuickHealDownrank_Slider_NH:SetMinMaxValues(1, 10);
-        QuickHealDownrank_Slider_NH:SetValue(10);
+        QuickHealDownrank_Slider_NH:SetValue(QuickHealVariables.DownrankValueNH or 10);
         QuickHealDownrank_Slider_FH:SetMinMaxValues(1, 6);
-        QuickHealDownrank_Slider_FH:SetValue(6);
+        QuickHealDownrank_Slider_FH:SetValue(QuickHealVariables.DownrankValueFH or 6);
         QuickHealMinrank_Slider_NH:SetMinMaxValues(1, 10);
         QuickHealMinrank_Slider_NH:SetValue(QuickHealVariables.MinrankValueNH);
-        QuickHealMinrank_Slider_FH:SetMinMaxValues(1, 6);
-        QuickHealMinrank_Slider_FH:SetValue(QuickHealVariables.MinrankValueFH);
         QuickHealMinrank_Slider_FH:SetMinMaxValues(1, 6);
         QuickHealMinrank_Slider_FH:SetValue(QuickHealVariables.MinrankValueFH);
 
@@ -1136,6 +1142,22 @@ local function Initialise()
         QuickHealDownrank_Label_FH:SetText("Lesser HW");
         QuickHealMinrank_Label_NH:SetText("Healing Wave");
         QuickHealMinrank_Label_FH:SetText("Lesser HW");
+
+        -- Chain Heal sliders (Shaman-specific) - show and configure
+        if QuickHealDownrank_Slider_CH then
+            QuickHealDownrank_Slider_CH:Show();
+            QuickHealDownrank_Label_CH:Show();
+            QuickHealDownrank_RankNumberCH:Show();
+            QuickHealDownrank_Slider_CH:SetMinMaxValues(1, 3);
+            QuickHealDownrank_Slider_CH:SetValue(QuickHealVariables.DownrankValueCH or 3);
+        end
+        if QuickHealMinrank_Slider_CH then
+            QuickHealMinrank_Slider_CH:Show();
+            QuickHealMinrank_Label_CH:Show();
+            QuickHealMinrank_RankNumberCH:Show();
+            QuickHealMinrank_Slider_CH:SetMinMaxValues(1, 3);
+            QuickHealMinrank_Slider_CH:SetValue(QuickHealVariables.MinrankValueCH or 1);
+        end
 
         SlashCmdList["QUICKHEAL"] = QuickHeal_Command_Shaman;
         SLASH_QUICKHEAL1 = "/qh";
@@ -1157,6 +1179,18 @@ local function Initialise()
         QuickHealDownrank_Label_FH:SetText("Flash Heal");
         QuickHealMinrank_Label_NH:SetText("Greater Heal");
         QuickHealMinrank_Label_FH:SetText("Flash Heal");
+
+        -- Hide Chain Heal sliders (Shaman only)
+        if QuickHealDownrank_Slider_CH then
+            QuickHealDownrank_Slider_CH:Hide();
+            QuickHealDownrank_Label_CH:Hide();
+            QuickHealDownrank_RankNumberCH:Hide();
+        end
+        if QuickHealMinrank_Slider_CH then
+            QuickHealMinrank_Slider_CH:Hide();
+            QuickHealMinrank_Label_CH:Hide();
+            QuickHealMinrank_RankNumberCH:Hide();
+        end
 
         SlashCmdList["QUICKHEAL"] = QuickHeal_Command_Priest;
         SLASH_QUICKHEAL1 = "/qh";
@@ -1196,6 +1230,19 @@ local function Initialise()
 
         QuickHealDownrank_RankNumberBot:SetPoint("CENTER", QuickHeal_DownrankSlider, "TOP", 108, -108); -- Reset position if it was moved
         QuickHealMinrank_Slider_FH:SetValue(QuickHealVariables.MinrankValueFH);
+
+        -- Hide Chain Heal sliders (Shaman only)
+        if QuickHealDownrank_Slider_CH then
+            QuickHealDownrank_Slider_CH:Hide();
+            QuickHealDownrank_Label_CH:Hide();
+            QuickHealDownrank_RankNumberCH:Hide();
+        end
+        if QuickHealMinrank_Slider_CH then
+            QuickHealMinrank_Slider_CH:Hide();
+            QuickHealMinrank_Label_CH:Hide();
+            QuickHealMinrank_RankNumberCH:Hide();
+        end
+
         SlashCmdList["QUICKHEAL"] = QuickHeal_Command_Paladin;
         SLASH_QUICKHEAL1 = "/qh";
         SLASH_QUICKHEAL2 = "/quickheal";
@@ -1221,6 +1268,18 @@ local function Initialise()
         QuickHealDownrank_Label_FH:SetText("Regrowth");
         QuickHealMinrank_Label_NH:SetText("Healing Touch");
         QuickHealMinrank_Label_FH:SetText("Regrowth");
+
+        -- Hide Chain Heal sliders (Shaman only)
+        if QuickHealDownrank_Slider_CH then
+            QuickHealDownrank_Slider_CH:Hide();
+            QuickHealDownrank_Label_CH:Hide();
+            QuickHealDownrank_RankNumberCH:Hide();
+        end
+        if QuickHealMinrank_Slider_CH then
+            QuickHealMinrank_Slider_CH:Hide();
+            QuickHealMinrank_Label_CH:Hide();
+            QuickHealMinrank_RankNumberCH:Hide();
+        end
 
         SlashCmdList["QUICKHEAL"] = QuickHeal_Command_Druid;
         SLASH_QUICKHEAL1 = "/qh";
@@ -3898,9 +3957,17 @@ function QuickHOT(Target, SpellID, extParam, forceMaxRank, noHpCheck)
 end
 
 function ToggleDownrankWindow()
-    QuickHeal_ToggleConfigurationPanel();
+    if not QuickHealConfig:IsVisible() then
+        QuickHealConfig:Show();
+    end
+    -- Hide all tab frames
+    QuickHealConfig_GeneralOptionsFrame:Hide();
+    QuickHealConfig_HealingTargetFilterFrame:Hide();
+    QuickHealConfig_MessagesAndNotificationFrame:Hide();
+    -- Show Ranks frame
+    QuickHealConfig_RanksFrame:Show();
+    -- Set tab selection
     PanelTemplates_SetTab(QuickHealConfig, 4);
-    QuickHealConfigTab4:Click();
 end
 
 ------------------------------------------------------------------------------------------------------------------------

--- a/QuickHeal.xml
+++ b/QuickHeal.xml
@@ -230,7 +230,7 @@
         <Scripts>
             <OnLoad>
                 this:RegisterForDrag("LeftButton");
-                PanelTemplates_SetNumTabs(this, 3);
+                PanelTemplates_SetNumTabs(this, 4);
                 PanelTemplates_SetTab(this, 1);
                 QuickHeal_OnLoad();
             </OnLoad>
@@ -1810,7 +1810,7 @@
     <!-- Ranks Options Frame -->
     <Frame name="QuickHealConfig_RanksFrame" frameStrata="DIALOG" toplevel="true" parent="QuickHealConfig" hidden="true">
         <Size>
-            <AbsDimension x="600" y="360"/>
+            <AbsDimension x="600" y="430"/>
         </Size>
         <Anchors>
             <Anchor point="CENTER"/>
@@ -1852,13 +1852,25 @@
                     </Anchors>
                 </FontString>
             </Layer>
+            <!-- Chain Heal Label (Downrank, Shaman only) -->
+            <Layer level="ARTWORK">
+                <FontString name="QuickHealDownrank_Label_CH" inherits="GameFontHighlightSmall" text="Chain Heal">
+                    <Anchors>
+                        <Anchor point="TOPLEFT">
+                            <Offset>
+                                <AbsDimension x="57" y="-180"/>
+                            </Offset>
+                        </Anchor>
+                    </Anchors>
+                </FontString>
+            </Layer>
             <!-- Minimum Rank Section Header -->
             <Layer level="ARTWORK">
                 <FontString name="QuickHealConfig_TextMinRank" inherits="GameFontNormal" text="Minimum Rank (if mana permits)">
                     <Anchors>
                         <Anchor point="TOPLEFT">
                             <Offset>
-                                <AbsDimension x="32" y="-175"/>
+                                <AbsDimension x="32" y="-230"/>
                             </Offset>
                         </Anchor>
                     </Anchors>
@@ -1870,7 +1882,7 @@
                     <Anchors>
                         <Anchor point="TOPLEFT">
                             <Offset>
-                                <AbsDimension x="57" y="-200"/>
+                                <AbsDimension x="57" y="-255"/>
                             </Offset>
                         </Anchor>
                     </Anchors>
@@ -1882,7 +1894,19 @@
                     <Anchors>
                         <Anchor point="TOPLEFT">
                             <Offset>
-                                <AbsDimension x="57" y="-250"/>
+                                <AbsDimension x="57" y="-305"/>
+                            </Offset>
+                        </Anchor>
+                    </Anchors>
+                </FontString>
+            </Layer>
+            <!-- Chain Heal Label (Minrank, Shaman only) -->
+            <Layer level="ARTWORK">
+                <FontString name="QuickHealMinrank_Label_CH" inherits="GameFontHighlightSmall" text="Chain Heal">
+                    <Anchors>
+                        <Anchor point="TOPLEFT">
+                            <Offset>
+                                <AbsDimension x="57" y="-355"/>
                             </Offset>
                         </Anchor>
                     </Anchors>
@@ -1917,7 +1941,7 @@
                     <Anchors>
                         <Anchor point="TOPLEFT">
                             <Offset>
-                                <AbsDimension x="500" y="-200"/>
+                                <AbsDimension x="500" y="-255"/>
                             </Offset>
                         </Anchor>
                     </Anchors>
@@ -1928,7 +1952,30 @@
                     <Anchors>
                         <Anchor point="TOPLEFT">
                             <Offset>
-                                <AbsDimension x="500" y="-250"/>
+                                <AbsDimension x="500" y="-305"/>
+                            </Offset>
+                        </Anchor>
+                    </Anchors>
+                </FontString>
+            </Layer>
+            <!-- Chain Heal rank display labels (Shaman only) -->
+            <Layer level="ARTWORK">
+                <FontString name="QuickHealDownrank_RankNumberCH" outline="NORMAL" inherits="GameFontNormal" text="">
+                    <Anchors>
+                        <Anchor point="TOPLEFT">
+                            <Offset>
+                                <AbsDimension x="500" y="-195"/>
+                            </Offset>
+                        </Anchor>
+                    </Anchors>
+                </FontString>
+            </Layer>
+            <Layer level="ARTWORK">
+                <FontString name="QuickHealMinrank_RankNumberCH" outline="NORMAL" inherits="GameFontNormal" text="">
+                    <Anchors>
+                        <Anchor point="TOPLEFT">
+                            <Offset>
+                                <AbsDimension x="500" y="-355"/>
                             </Offset>
                         </Anchor>
                     </Anchors>
@@ -1952,7 +1999,6 @@
                     <OnLoad>
                         this:SetMinMaxValues(1,12);
                         this:SetValueStep(1);
-                        this:SetValue(12)
                     </OnLoad>
                     <OnValueChanged>
                         QuickHealVariables["DownrankValueNH"] = this:GetValue();
@@ -1989,7 +2035,6 @@
                     <OnLoad>
                         this:SetMinMaxValues(1,7);
                         this:SetValueStep(1);
-                        this:SetValue(7)
                     </OnLoad>
                     <OnValueChanged>
                         QuickHealVariables["DownrankValueFH"] = this:GetValue();
@@ -2018,7 +2063,7 @@
                 <Anchors>
                     <Anchor point="TOPLEFT">
                         <Offset>
-                            <AbsDimension x="50" y="-215"/>
+                            <AbsDimension x="50" y="-270"/>
                         </Offset>
                     </Anchor>
                 </Anchors>
@@ -2055,7 +2100,7 @@
                 <Anchors>
                     <Anchor point="TOPLEFT">
                         <Offset>
-                            <AbsDimension x="50" y="-265"/>
+                            <AbsDimension x="50" y="-320"/>
                         </Offset>
                     </Anchor>
                 </Anchors>
@@ -2075,6 +2120,80 @@
                     <OnEnter>
                         GameTooltip:SetOwner(this,"ANCHOR_TOPLEFT");
                         GameTooltip:SetText(QuickHealMinrank_Label_FH:GetText());
+                        this.tooltipShown = true;
+                    </OnEnter>
+                    <OnLeave>
+                        GameTooltip:Hide();
+                        this.tooltipShown = false;
+                    </OnLeave>
+                </Scripts>
+            </Slider>
+
+            <!-- Downrank Slider CH (Chain Heal, Shaman only) -->
+            <Slider name="QuickHealDownrank_Slider_CH" inherits="OptionsSliderTemplate">
+                <Size>
+                    <AbsDimension x="400" y="16"/>
+                </Size>
+                <Anchors>
+                    <Anchor point="TOPLEFT">
+                        <Offset>
+                            <AbsDimension x="50" y="-195"/>
+                        </Offset>
+                    </Anchor>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        this:SetMinMaxValues(1,3);
+                        this:SetValueStep(1);
+                        this:SetValue(3)
+                    </OnLoad>
+                    <OnValueChanged>
+                        QuickHealVariables["DownrankValueCH"] = this:GetValue();
+                        QuickHealDownrank_RankNumberCH:SetText(QuickHealVariables["DownrankValueCH"]);
+                    </OnValueChanged>
+                    <OnShow>
+                        this:SetValue(QuickHealVariables["DownrankValueCH"] or 3);
+                    </OnShow>
+                    <OnEnter>
+                        GameTooltip:SetOwner(this,"ANCHOR_TOPLEFT");
+                        GameTooltip:SetText(QuickHealDownrank_Label_CH:GetText());
+                        this.tooltipShown = true;
+                    </OnEnter>
+                    <OnLeave>
+                        GameTooltip:Hide();
+                        this.tooltipShown = false;
+                    </OnLeave>
+                </Scripts>
+            </Slider>
+
+            <!-- Minrank Slider CH (Chain Heal, Shaman only) -->
+            <Slider name="QuickHealMinrank_Slider_CH" inherits="OptionsSliderTemplate">
+                <Size>
+                    <AbsDimension x="400" y="16"/>
+                </Size>
+                <Anchors>
+                    <Anchor point="TOPLEFT">
+                        <Offset>
+                            <AbsDimension x="50" y="-370"/>
+                        </Offset>
+                    </Anchor>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        this:SetMinMaxValues(1,3);
+                        this:SetValueStep(1);
+                        this:SetValue(1)
+                    </OnLoad>
+                    <OnValueChanged>
+                        QuickHealVariables["MinrankValueCH"] = this:GetValue();
+                        QuickHealMinrank_RankNumberCH:SetText(QuickHealVariables["MinrankValueCH"]);
+                    </OnValueChanged>
+                    <OnShow>
+                        this:SetValue(QuickHealVariables["MinrankValueCH"] or 1);
+                    </OnShow>
+                    <OnEnter>
+                        GameTooltip:SetOwner(this,"ANCHOR_TOPLEFT");
+                        GameTooltip:SetText(QuickHealMinrank_Label_CH:GetText());
                         this.tooltipShown = true;
                     </OnEnter>
                     <OnLeave>

--- a/QuickHealShaman.lua
+++ b/QuickHealShaman.lua
@@ -132,7 +132,11 @@ function QuickHeal_Shaman_FindChainHealSpellToUse(target, healType, multiplier, 
     local SpellIDsCH = QuickHeal_GetSpellIDs(QUICKHEAL_SPELL_CHAIN_HEAL)
     local maxRankCH = table.getn(SpellIDsCH)
 
-    debug(string.format("Found CH up to rank %d", maxRankCH))
+    -- Chain Heal downrank settings
+    local downRankCH = QuickHealVariables.DownrankValueCH or 3
+    local minRankCH = QuickHealVariables.MinrankValueCH or 1
+
+    debug(string.format("Found CH up to rank %d, downrank limit: %d, minrank: %d", maxRankCH, downRankCH, minRankCH))
 
     local tfMod = mods.tfMod
     local healModCH = mods.healModCH
@@ -140,15 +144,32 @@ function QuickHeal_Shaman_FindChainHealSpellToUse(target, healType, multiplier, 
     local K = 0.8 -- Combat compensation for slow spells
 
     if not forceMaxRank then
-        SpellID = SpellIDsCH[1]; HealSize = 356 + healMod25
-        if healneed > (898 + healModCH) * hwMod * K and ManaLeft >= 315 * tfMod and maxRankCH >= 2 and SpellIDsCH[2] then
+        -- Start with lowest rank within min/max range (default: rank 1)
+        if maxRankCH >= 1 and minRankCH <= 1 and downRankCH >= 1 and SpellIDsCH[1] then
+            SpellID = SpellIDsCH[1]; HealSize = 356 + healMod25
+        elseif maxRankCH >= 2 and minRankCH <= 2 and downRankCH >= 2 and SpellIDsCH[2] then
+            SpellID = SpellIDsCH[2]; HealSize = 449 + healModCH
+        elseif maxRankCH >= 3 and minRankCH <= 3 and downRankCH >= 3 and SpellIDsCH[3] then
+            SpellID = SpellIDsCH[3]; HealSize = 607 + healModCH
+        end
+
+        -- Upgrade to rank 2 if heal need exceeds threshold (original: 898 = ~2x base heal)
+        if healneed > (898 + healModCH) * hwMod * K and ManaLeft >= 315 * tfMod and maxRankCH >= 2 and minRankCH <= 2 and downRankCH >= 2 and SpellIDsCH[2] then
             SpellID = SpellIDsCH[2]; HealSize = (449 + healModCH) * hwMod
         end
-        if healneed > (1213 + healModCH) * hwMod * K and ManaLeft >= 405 * tfMod and maxRankCH >= 3 and SpellIDsCH[3] then
+        -- Upgrade to rank 3 if heal need exceeds threshold (original: 1213 = ~2x base heal)
+        if healneed > (1213 + healModCH) * hwMod * K and ManaLeft >= 405 * tfMod and maxRankCH >= 3 and minRankCH <= 3 and downRankCH >= 3 and SpellIDsCH[3] then
             SpellID = SpellIDsCH[3]; HealSize = (607 + healModCH) * hwMod
         end
     else
-        SpellID = SpellIDsCH[3]; HealSize = 607 * hwMod + healMod25
+        -- Force max rank available within downrank limit
+        if maxRankCH >= 3 and downRankCH >= 3 and SpellIDsCH[3] then
+            SpellID = SpellIDsCH[3]; HealSize = 607 * hwMod + healMod25
+        elseif maxRankCH >= 2 and downRankCH >= 2 and SpellIDsCH[2] then
+            SpellID = SpellIDsCH[2]; HealSize = (449 + healModCH) * hwMod
+        elseif maxRankCH >= 1 and downRankCH >= 1 and SpellIDsCH[1] then
+            SpellID = SpellIDsCH[1]; HealSize = 356 + healMod25
+        end
     end
 
     debug(string.format("SpellID: %s  HealSize: %s", tostring(SpellID), tostring(HealSize)))
@@ -234,7 +255,9 @@ function QuickHeal_Shaman_FindHealSpellToUse(target, healType, multiplier, force
     local healModLHW = mods.healModLHW
     local healMod15, healMod20, healMod25, healMod30 = mods.healMod15, mods.healMod20, mods.healMod25, mods.healMod30
 
-    local TargetIsHealthy = Health >= RatioHealthy
+    -- When RatioHealthy is 0, we want to allow HW freely (not restrict it)
+    -- Setting TargetIsHealthy to false when RatioHealthy <= 0 removes HW restrictions
+    local TargetIsHealthy = RatioHealthy > 0 and Health >= RatioHealthy
     if TargetIsHealthy then
         debug("Target is healthy", Health)
     end
@@ -265,37 +288,37 @@ function QuickHeal_Shaman_FindHealSpellToUse(target, healType, multiplier, force
             if (healneed > (264 + healModLHW) * hwMod * k or 2 <= minRankFH) and ManaLeft >= 145 * tfMod and maxRankLHW >= 2 and downRankFH >= 2 and SpellIDsLHW[2] then
                 SpellID = SpellIDsLHW[2]; HealSize = (264 + healModLHW) * hwMod
             end
-            if (healneed > (292 + healMod30 * PF[18]) * hwMod * K or 4 <= minRankNH) and ManaLeft >= 155 * tfMod and maxRankHW >= 4 and downRankNH >= 4 and (TargetIsHealthy and maxRankLHW <= 2 and downRankFH <= 2 or NoLHW) and SpellIDsHW[4] then
+            if (healneed > (292 + healMod30 * PF[18]) * hwMod * K or 4 <= minRankNH) and ManaLeft >= 155 * tfMod and maxRankHW >= 4 and downRankNH >= 4 and (not TargetIsHealthy or (TargetIsHealthy and downRankFH <= 2) or NoLHW) and SpellIDsHW[4] then
                 SpellID = SpellIDsHW[4]; HealSize = (292 + healMod30 * PF[18]) * hwMod
             end
             if (healneed > (359 + healModLHW) * hwMod * k or 3 <= minRankFH) and ManaLeft >= 185 * tfMod and maxRankLHW >= 3 and downRankFH >= 3 and SpellIDsLHW[3] then
                 SpellID = SpellIDsLHW[3]; HealSize = (359 + healModLHW) * hwMod
             end
-            if (healneed > (408 + healMod30) * hwMod * K or 5 <= minRankNH) and ManaLeft >= 200 * tfMod and maxRankHW >= 5 and downRankNH >= 5 and (TargetIsHealthy and maxRankLHW <= 3 and downRankFH <= 3 or NoLHW) and SpellIDsHW[5] then
+            if (healneed > (408 + healMod30) * hwMod * K or 5 <= minRankNH) and ManaLeft >= 200 * tfMod and maxRankHW >= 5 and downRankNH >= 5 and (not TargetIsHealthy or (TargetIsHealthy and downRankFH <= 3) or NoLHW) and SpellIDsHW[5] then
                 SpellID = SpellIDsHW[5]; HealSize = (408 + healMod30) * hwMod
             end
             if (healneed > (486 + healModLHW) * hwMod * k or 4 <= minRankFH) and ManaLeft >= 235 * tfMod and maxRankLHW >= 4 and downRankFH >= 4 and SpellIDsLHW[4] then
                 SpellID = SpellIDsLHW[4]; HealSize = (486 + healModLHW) * hwMod
             end
-            if (healneed > (579 + healMod30) * hwMod * K or 6 <= minRankNH) and ManaLeft >= 265 * tfMod and maxRankHW >= 6 and downRankNH >= 6 and (TargetIsHealthy and maxRankLHW <= 4 and downRankFH <= 4 or NoLHW) and SpellIDsHW[6] then
+            if (healneed > (579 + healMod30) * hwMod * K or 6 <= minRankNH) and ManaLeft >= 265 * tfMod and maxRankHW >= 6 and downRankNH >= 6 and (not TargetIsHealthy or (TargetIsHealthy and downRankFH <= 4) or NoLHW) and SpellIDsHW[6] then
                 SpellID = SpellIDsHW[6]; HealSize = (579 + healMod30) * hwMod
             end
             if (healneed > (668 + healModLHW) * hwMod * k or 5 <= minRankFH) and ManaLeft >= 305 * tfMod and maxRankLHW >= 5 and downRankFH >= 5 and SpellIDsLHW[5] then
                 SpellID = SpellIDsLHW[5]; HealSize = (668 + healModLHW) * hwMod
             end
-            if (healneed > (797 + healMod30) * hwMod * K or 7 <= minRankNH) and ManaLeft >= 340 * tfMod and maxRankHW >= 7 and downRankNH >= 7 and (TargetIsHealthy and maxRankLHW <= 5 and downRankFH <= 5 or NoLHW) and SpellIDsHW[7] then
+            if (healneed > (797 + healMod30) * hwMod * K or 7 <= minRankNH) and ManaLeft >= 340 * tfMod and maxRankHW >= 7 and downRankNH >= 7 and (not TargetIsHealthy or (TargetIsHealthy and downRankFH <= 5) or NoLHW) and SpellIDsHW[7] then
                 SpellID = SpellIDsHW[7]; HealSize = (797 + healMod30) * hwMod
             end
             if (healneed > (880 + healModLHW) * hwMod * k or 6 <= minRankFH) and ManaLeft >= 380 * tfMod and maxRankLHW >= 6 and downRankFH >= 6 and SpellIDsLHW[6] then
                 SpellID = SpellIDsLHW[6]; HealSize = (880 + healModLHW) * hwMod
             end
-            if (healneed > (1092 + healMod30) * hwMod * K or 8 <= minRankNH) and ManaLeft >= 440 * tfMod and maxRankHW >= 8 and downRankNH >= 8 and (TargetIsHealthy and maxRankLHW <= 6 and downRankFH <= 6 or NoLHW) and SpellIDsHW[8] then
+            if (healneed > (1092 + healMod30) * hwMod * K or 8 <= minRankNH) and ManaLeft >= 440 * tfMod and maxRankHW >= 8 and downRankNH >= 8 and (not TargetIsHealthy or (TargetIsHealthy and downRankFH <= 6) or NoLHW) and SpellIDsHW[8] then
                 SpellID = SpellIDsHW[8]; HealSize = (1092 + healMod30) * hwMod
             end
-            if (healneed > (1464 + healMod30) * hwMod * K or 9 <= minRankNH) and ManaLeft >= 560 * tfMod and maxRankHW >= 9 and downRankNH >= 9 and (TargetIsHealthy and maxRankLHW <= 6 and downRankFH <= 6 or NoLHW) and SpellIDsHW[9] then
+            if (healneed > (1464 + healMod30) * hwMod * K or 9 <= minRankNH) and ManaLeft >= 560 * tfMod and maxRankHW >= 9 and downRankNH >= 9 and (not TargetIsHealthy or (TargetIsHealthy and downRankFH <= 6) or NoLHW) and SpellIDsHW[9] then
                 SpellID = SpellIDsHW[9]; HealSize = (1464 + healMod30) * hwMod
             end
-            if (healneed > (1735 + healMod30) * hwMod * K or 10 <= minRankNH) and ManaLeft >= 620 * tfMod and maxRankHW >= 10 and downRankNH >= 10 and (TargetIsHealthy and maxRankLHW <= 6 and downRankFH <= 6 or NoLHW) and SpellIDsHW[10] then
+            if (healneed > (1735 + healMod30) * hwMod * K or 10 <= minRankNH) and ManaLeft >= 620 * tfMod and maxRankHW >= 10 and downRankNH >= 10 and (not TargetIsHealthy or (TargetIsHealthy and downRankFH <= 6) or NoLHW) and SpellIDsHW[10] then
                 SpellID = SpellIDsHW[10]; HealSize = (1735 + healMod30) * hwMod
             end
         end


### PR DESCRIPTION
This PR adds downrank support to Chain Heal for shamans, and also fixes a logic bug that was forcing LHW instead of HW even if the healthy bar was set all the way to 0%. It also now properly chooses between LHW and HW based on the maximum downrank version slider versus the max rank learned, and saves the downranks properly (it previous reset them to 10 and 6 on reload)

- Fix RatioHealthyShaman=0% bug preventing Healing Wave usage
- Add Chain Heal min/max rank configuration sliders (similar to HW/LHW)
- Fix UI layout: adjust frame height and slider positioning
- Fix tab selection bug (PanelTemplates_SetNumTabs)
- Fix Chain Heal spell selection logic and threshold values
- Fix Healing Wave selection to respect LHW downrank slider when target is healthy
- Fix /qh dr showing wrong tab content (GeneralOptions instead of Ranks)
- Fix HW/LHW downrank sliders not persisting (remove OnLoad defaults, load from saved vars)

The logic was confusing for how it figured out which spells to cast. I passed it through Claude and the proposed fix to the logic is in this PR with the following explanation:

Looking at lines 2296-2320, QuickHeal_GetSpellIDs() scans your entire spellbook and returns ALL ranks you've learned,
regardless of slider settings. It doesn't filter by the downrank slider at all.

So:
  - maxRankLHW = table.getn(SpellIDsLHW) = all LHW ranks learned (not slider-controlled)
  - downRankFH = your max rank slider setting (what you control in UI)

Now let me reconsider the original logic:

Original: (TargetIsHealthy and maxRankLHW <= 2 and downRankFH <= 2)

This says: "Only use HW when target is healthy if you've learned 2 or fewer LHW ranks AND your slider is at 2 or
  less."

The intent seems to be: Don't use slow HW on healthy targets if you have access to fast high-rank LHW.

But your use case breaks this: You've learned all 6 LHW ranks, set your slider to rank 1 to restrict LHW, but HW still
   won't be used because maxRankLHW = 6 fails the <= 2 check.