### PR TITLE
Fix Spellcast Bar when spamming

### DIFF
--- a/QuickHeal.lua
+++ b/QuickHeal.lua
@@ -3405,8 +3405,13 @@ end
 local function ExecuteHeal(Target, SpellID)
     local TargetWasChanged = false;
 
+    -- Unregister casting events BEFORE stopping the cast, so the SPELLCAST_STOP
+    -- event from the previous cast doesn't race with StartMonitor and hide bars
+    QuickHealConfig:UnregisterEvent("SPELLCAST_STOP");
+    QuickHealConfig:UnregisterEvent("SPELLCAST_FAILED");
+    QuickHealConfig:UnregisterEvent("SPELLCAST_INTERRUPTED");
+
     -- Clear any pending spell state BEFORE starting monitor
-    -- (SpellStopCasting triggers SPELLCAST_STOP which would immediately stop monitor)
     if SpellIsTargeting() then
         SpellStopTargeting()
     end


### PR DESCRIPTION
Fixes spellcast bar when spamming /qh, helps with issue #13 

**Before**: SpellStopCasting() fires a SPELLCAST_STOP event → the event handler calls StopMonitor() → hides the healing bar. Then StartMonitor() shows it again, but the event can fire after that too (race condition) → bar disappears permanently even though the new spell is casting.

  **After**: The three casting events are unregistered before SpellStopCasting(), so the stop from the old cast is ignored. StartMonitor() then re-registers them fresh for the newcast. No race condition, bar stays visible.